### PR TITLE
:NORMAL: Feature/remove-jcenter [SMALL]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 	}
 
 	dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
 	repositories {
 		google()
-		jcenter()
+		mavenCentral()
 		maven { url "https://maven.google.com" }
 
 		maven {


### PR DESCRIPTION
**What**

- Removed jCenter from the build files and replaced with mavenCentral

**Why?**

- Need to remove jCenter so we can consistently build our apps

**Anything Else**

- Don't think this bump is strictly necessary as it is only the example that uses jCenter. However, I have removed for consistency. 